### PR TITLE
Add argoproj-labs org to CNCF settings

### DIFF
--- a/cncf/settings.yml
+++ b/cncf/settings.yml
@@ -5,6 +5,7 @@ organizations:
   - aeraki-mesh
   - antrea-io
   - argoproj
+  - argoproj-labs
   - armadaproject
   - artifacthub
   - AthenZ


### PR DESCRIPTION
Contributions to argoproj-labs repositories (e.g. argocd-image-updater) were not being counted since the org wasn't in the scan list, even though the main argoproj org was.

Fixes #18